### PR TITLE
[Feature] render props

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ import React from "react";
 import { AppRegistry, Text, View } from "react-vr";
 
 // import
-const withAwareness = require("react-vr-with-awareness");
+const Aware, {withAwareness} = require("react-vr-with-awareness");
 
-// create component
-const AwareComponent = withAwareness(({ beingLookedAt }) => (
+// create a component with HOC
+const AwareFromHOC = withAwareness(beingLookedAt => (
   <Text
     style={{
       backgroundColor: "#777879",
@@ -30,11 +30,33 @@ const AwareComponent = withAwareness(({ beingLookedAt }) => (
     {beingLookedAt ? "Hi there!" : "Look at me!"}
   </Text>
 ));
+
+// or use the supplied component `Aware` with render props
 export default class example extends React.Component {
   render() {
     return (
       <View>
-        <AwareComponent />
+        {/* Aware component from HOC */}
+        <AwareFromHOC />
+        
+        {/* Aware component with render props */}
+        <Aware render={seen => (
+          <Text
+              style={{
+                backgroundColor: "#777879",
+                fontSize: 0.8,
+                fontWeight: "400",
+                layoutOrigin: [0.5, 0.5],
+                paddingLeft: 0.2,
+                paddingRight: 0.2,
+                textAlign: "center",
+                textAlignVertical: "center",
+                transform: [{ translate: [0, 2, -3] }]
+              }}
+            >
+              {seen ? "seen" : "not seen"}
+            </Text>
+        )}/>
       </View>
     );
   }
@@ -42,6 +64,10 @@ export default class example extends React.Component {
 
 AppRegistry.registerComponent("example", () => example);
 ```
+
+## Docs
+
+`Aware` component takes a `render` props which is a function with 1 `boolean` parameter which indicates if the component is being seen or not. The function should return a react component. This function is similar from the one used in the HOC.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,16 +2,22 @@
   "name": "react-vr-with-awareness",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "files": ["package.json", "README.md", "LICENSE", "dist"],
+  "files": [
+    "package.json",
+    "README.md",
+    "LICENSE",
+    "dist"
+  ],
   "repository": "git@github.com:mathdroid/with-awareness",
   "author": "<muhammad.mustadi@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "react": "^15.5.4",
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.4.0",
-    "np": "^2.13.2"
+    "np": "^2.13.2",
+    "prop-types": "^15.6.0",
+    "react": "^15.5.4"
   },
   "scripts": {
     "release": "np",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,8 @@
 {
   "name": "react-vr-with-awareness",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
-  "files": [
-    "package.json",
-    "README.md",
-    "LICENSE",
-    "dist"
-  ],
+  "files": ["package.json", "README.md", "LICENSE", "dist"],
   "repository": "git@github.com:mathdroid/with-awareness",
   "author": "<muhammad.mustadi@gmail.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,36 +1,39 @@
 const React = require("react");
+const PropTypes = require("prop-types");
 
-const withAwareness = fn =>
-  class extends React.Component {
-    constructor() {
-      super();
-      this.state = {
-        beingLookedAt: false
-      };
-      this.handleEnter = this.handleEnter.bind(this);
-      this.handleExit = this.handleExit.bind(this);
-    }
+const withAwareness = fn => <Aware render={fn} />;
 
-    handleEnter() {
-      this.setState({ beingLookedAt: true });
-    }
+class Aware extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      beingLookedAt: false
+    };
+    this.handleEnter = this.handleEnter.bind(this);
+    this.handleExit = this.handleExit.bind(this);
+  }
 
-    handleExit() {
-      this.setState({ beingLookedAt: false });
-    }
+  handleEnter() {
+    this.setState({ beingLookedAt: true });
+  }
 
-    render() {
-      const { beingLookedAt } = this.state;
-      return React.cloneElement(
-        fn({
-          beingLookedAt
-        }),
-        {
-          onEnter: this.handleEnter,
-          onExit: this.handleExit
-        }
-      );
-    }
-  };
+  handleExit() {
+    this.setState({ beingLookedAt: false });
+  }
 
-module.exports = withAwareness;
+  render() {
+    const { beingLookedAt } = this.state;
+    return React.cloneElement(this.props.render(beingLookedAt), {
+      onEnter: this.handleEnter,
+      onExit: this.handleExit
+    });
+  }
+}
+
+Aware.propTypes = {
+  render: PropTypes.func.isRequired
+};
+
+Aware.withAwareness = withAwareness;
+
+module.exports = Aware;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,18 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
@@ -1634,7 +1646,7 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -1833,7 +1845,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2016,6 +2028,14 @@ prop-types@^15.5.7:
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -2043,10 +2063,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-vr@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-vr/-/react-vr-1.0.0.tgz#57ce7faa6149f900dbdae9ea9ff42c06a5e2ea1b"
 
 react@^15.5.4:
   version "15.5.4"


### PR DESCRIPTION
Add support for render props. For this, we need to change the `module.exports` to export both the HOC and the component.

What's changed: 

- Main export is now an `Aware` component that receives a `render` prop. `withComponent` HOC is available in `Aware.withComponent`.

- The argument in the function for `render` prop and HOC is now a `boolean` instead of an `Object` with `beingLookedAt` property.